### PR TITLE
[fix](nginx):将静态文件大小上限设置为5m，解决413报错

### DIFF
--- a/nginx_dev.conf
+++ b/nginx_dev.conf
@@ -14,6 +14,7 @@ http {
   access_log /var/log/nginx/access.log main;
   sendfile on;
   keepalive_timeout 65;
+  client_max_body_size 5m;
   server {
     # listen 80;
     listen 443 ssl;

--- a/nginx_prod.conf
+++ b/nginx_prod.conf
@@ -14,6 +14,7 @@ http {
   access_log /var/log/nginx/access.log main;
   sendfile on;
   keepalive_timeout 65;
+  client_max_body_size 5m;
   server {
     # listen 80;
     listen 443 ssl;


### PR DESCRIPTION
close #133 